### PR TITLE
IMB-189: validate name and description length for set

### DIFF
--- a/mobile/lib/app/Profile/widgets/set_form.dart
+++ b/mobile/lib/app/Profile/widgets/set_form.dart
@@ -69,7 +69,7 @@ class SetForm extends ConsumerWidget {
             ),
             validator: FormBuilderValidators.compose([
               FormBuilderValidators.required(),
-              FormBuilderValidators.maxLength(maxSetNameLength),
+              FormBuilderValidators.maxLength(kMaxSetNameLength),
             ]),
           ),
           const SizedBox(height: 16),
@@ -81,7 +81,7 @@ class SetForm extends ConsumerWidget {
               border: OutlineInputBorder(),
             ),
             maxLines: null,
-            validator: FormBuilderValidators.maxLength(maxSetDescriptionLength),
+            validator: FormBuilderValidators.maxLength(kMaxSetDescriptionLength),
           ),
           const SizedBox(height: 16),
           ElevatedButton(

--- a/mobile/lib/app/Profile/widgets/set_form.dart
+++ b/mobile/lib/app/Profile/widgets/set_form.dart
@@ -9,6 +9,7 @@ import 'package:mobile/app/Set/presentation/set_screen_controller.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/utils/async_value_ui.dart';
+import 'package:mobile/shared/constants.dart';
 
 class SetForm extends ConsumerWidget {
   const SetForm(this.set, {super.key});
@@ -66,7 +67,10 @@ class SetForm extends ConsumerWidget {
               labelText: 'Name',
               border: OutlineInputBorder(),
             ),
-            validator: FormBuilderValidators.required(),
+            validator: FormBuilderValidators.compose([
+              FormBuilderValidators.required(),
+              FormBuilderValidators.maxLength(maxSetNameLength),
+            ]),
           ),
           const SizedBox(height: 16),
           FormBuilderTextField(
@@ -77,6 +81,7 @@ class SetForm extends ConsumerWidget {
               border: OutlineInputBorder(),
             ),
             maxLines: null,
+            validator: FormBuilderValidators.maxLength(maxSetDescriptionLength),
           ),
           const SizedBox(height: 16),
           ElevatedButton(

--- a/mobile/lib/app/Set/domain/set.dart
+++ b/mobile/lib/app/Set/domain/set.dart
@@ -11,11 +11,11 @@ typedef SetsFlashcards = ({String image_url});
 class Set with _$Set {
   const factory Set({
     required String id,
-    @Assert('name.length <= ${maxSetNameLength}',
-        'Name should not be more than ${maxSetNameLength} characters')
+    @Assert('name.length <= ${kMaxSetNameLength}',
+        'Name should not be more than ${kMaxSetNameLength} characters')
     String name,
-    @Assert('description.length <= ${maxSetDescriptionLength}',
-        'Description should not be more than ${maxSetDescriptionLength} characters')
+    @Assert('description.length <= ${kMaxSetDescriptionLength}',
+        'Description should not be more than ${kMaxSetDescriptionLength} characters')
     String? description,
     required String userId,
     required DateTime createdAt,

--- a/mobile/lib/app/Set/domain/set.dart
+++ b/mobile/lib/app/Set/domain/set.dart
@@ -11,8 +11,12 @@ typedef SetsFlashcards = ({String image_url});
 class Set with _$Set {
   const factory Set({
     required String id,
-    @NameValidation()  String name,
-    @DescriptionValidation() String? description,
+    @Assert('name.length <= ${maxSetNameLength}',
+        'Name should not be more than ${maxSetNameLength} characters')
+    String name,
+    @Assert('description.length <= ${maxSetDescriptionLength}',
+        'Description should not be more than ${maxSetDescriptionLength} characters')
+    String? description,
     required String userId,
     required DateTime createdAt,
     required DateTime updatedAt,
@@ -20,34 +24,4 @@ class Set with _$Set {
   }) = _Set;
 
   factory Set.fromJson(Map<String, dynamic> json) => _$SetFromJson(json);
-}
-
-class NameValidation implements JsonConverter<String, String> {
-  const NameValidation();
-
-  @override
-  String fromJson(String json) {
-    if (json.length > maxSetNameLength) {
-      throw ArgumentError('Name cannot be longer than ${maxSetNameLength} characters');
-    }
-    return json;
-  }
-
-  @override
-  String toJson(String object) => object;
-}
-
-class DescriptionValidation implements JsonConverter<String?, String?> {
-  const DescriptionValidation();
-
-  @override
-  String? fromJson(String? json) {
-    if (json != null && json.length > maxSetDescriptionLength) {
-      throw ArgumentError('Description cannot be longer than ${maxSetDescriptionLength} characters');
-    }
-    return json;
-  }
-
-  @override
-  String? toJson(String? object) => object;
 }

--- a/mobile/lib/app/Set/domain/set.dart
+++ b/mobile/lib/app/Set/domain/set.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-
+import 'package:mobile/shared/constants.dart';
 part 'set.freezed.dart';
 part 'set.g.dart';
 
@@ -11,8 +11,8 @@ typedef SetsFlashcards = ({String image_url});
 class Set with _$Set {
   const factory Set({
     required String id,
-    required String name,
-    String? description,
+    @NameValidation()  String name,
+    @DescriptionValidation() String? description,
     required String userId,
     required DateTime createdAt,
     required DateTime updatedAt,
@@ -20,4 +20,34 @@ class Set with _$Set {
   }) = _Set;
 
   factory Set.fromJson(Map<String, dynamic> json) => _$SetFromJson(json);
+}
+
+class NameValidation implements JsonConverter<String, String> {
+  const NameValidation();
+
+  @override
+  String fromJson(String json) {
+    if (json.length > maxSetNameLength) {
+      throw ArgumentError('Name cannot be longer than ${maxSetNameLength} characters');
+    }
+    return json;
+  }
+
+  @override
+  String toJson(String object) => object;
+}
+
+class DescriptionValidation implements JsonConverter<String?, String?> {
+  const DescriptionValidation();
+
+  @override
+  String? fromJson(String? json) {
+    if (json != null && json.length > maxSetDescriptionLength) {
+      throw ArgumentError('Description cannot be longer than ${maxSetDescriptionLength} characters');
+    }
+    return json;
+  }
+
+  @override
+  String? toJson(String? object) => object;
 }

--- a/mobile/lib/shared/constants.dart
+++ b/mobile/lib/shared/constants.dart
@@ -1,4 +1,4 @@
 const kStubImageUrl = 'https://placehold.co/110@2x.png?text=No+Picture';
 
-const maxSetNameLength = 50;
-const maxSetDescriptionLength = 200;
+const maxSetNameLength = 250;
+const maxSetDescriptionLength = 1500;

--- a/mobile/lib/shared/constants.dart
+++ b/mobile/lib/shared/constants.dart
@@ -1,1 +1,4 @@
 const kStubImageUrl = 'https://placehold.co/110@2x.png?text=No+Picture';
+
+const maxSetNameLength = 50;
+const maxSetDescriptionLength = 200;

--- a/mobile/lib/shared/constants.dart
+++ b/mobile/lib/shared/constants.dart
@@ -1,4 +1,4 @@
 const kStubImageUrl = 'https://placehold.co/110@2x.png?text=No+Picture';
 
-const maxSetNameLength = 250;
-const maxSetDescriptionLength = 1500;
+const kMaxSetNameLength = 250;
+const kMaxSetDescriptionLength = 1500;

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1275,10 +1275,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## Overview

Bug - There is no limit to the number of characters in fields “name” and “description” when creating a set

## Test cases

1. Use log in app
2. Go to profile
3. Chose set and click on “create”
4. Fill the field “name” - 500 different characters
5. Fill the field “description” - 600 different characters, using new string lines

## Issue

closes [189](https://www.notion.so/Bug-There-is-no-limit-to-the-number-of-characters-in-fields-name-and-description-when-creating-50b8c562641146408eebb31b59bc5e51)
