### PR TITLE
[Bugfix] Fix the crash when a user tries to sign in on an iOS device

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -29,7 +29,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.222626452683-gpqqh6k9lmndj9r4grokf9e2qkrsccld</string>
+				<string>com.googleusercontent.apps.222626452683-823iovqtt4e9aukg6rl8bkr6c34oj7r5</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Overview

This PR will allow a user to sign-in on ios devices

## Test cases

1. Open the app using iOS device as a new user
2. Try to sign in
