### PR TITLE
IMB-336: Get rid of the Navigator for the basic navigation

### DIFF
--- a/mobile/lib/app/Feedback/presentation/feedback_screen.dart
+++ b/mobile/lib/app/Feedback/presentation/feedback_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +17,7 @@ import 'package:mobile/components/button.dart';
 import 'package:mobile/utils/async_value_ui.dart';
 import 'package:mobile/widgets/input.dart';
 
+@RoutePage()
 class FeedbackScreen extends ConsumerStatefulWidget {
   const FeedbackScreen({super.key});
 
@@ -25,7 +27,7 @@ class FeedbackScreen extends ConsumerStatefulWidget {
 
 class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
   _onCancel() {
-    Navigator.pop(context);
+    AutoRouter.of(context).maybePop();
   }
 
   final _formKey = GlobalKey<FormBuilderState>();
@@ -44,7 +46,7 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
 
           showDialog(
             context: context,
-            builder: (context) => FeedbackReceivedDialog(),
+            builder: (context) => const FeedbackReceivedDialog(),
           );
         }
       });

--- a/mobile/lib/app/Feedback/presentation/feedback_screen.dart
+++ b/mobile/lib/app/Feedback/presentation/feedback_screen.dart
@@ -77,14 +77,14 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
         data: (data) => Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            TypeSetting(
+            const TypeSetting(
               "We're very sorry. Let us know what happened and we'll fix it",
               variant: TextVariants.headlineMedium,
             ),
             const SizedBox(
               height: 16,
             ),
-            TypeSetting(
+            const TypeSetting(
               "Note: this flashcard will be deleted once you submit a feedback",
               variant: TextVariants.bodySmall,
               style: TextStyle(color: AppColors.lightGrey),
@@ -161,11 +161,11 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
             )
           ],
         ),
-        error: (error, _) => TypeSetting('Oops, something went wrong'),
-        loading: () => TypeSetting('Loading...'),
+        error: (error, _) => const TypeSetting('Oops, something went wrong'),
+        loading: () => const TypeSetting('Loading...'),
       ),
       appBar: AppBar(
-        title: TypeSetting(
+        title: const TypeSetting(
           'Provide a feedback',
           variant: TextVariants.headlineLarge,
         ),

--- a/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
+++ b/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
@@ -1,8 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Feedback/widgets/feedback_received_dialog_controller.dart';
 import 'package:mobile/app/Flashcard/application/flashcard_providers.dart';
-import 'package:mobile/app/Home/presentation/home.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/components/button.dart';
 import 'package:mobile/utils/async_value_ui.dart';
@@ -18,12 +19,7 @@ class FeedbackReceivedDialog extends ConsumerStatefulWidget {
 class _FeedbackReceivedDialogState
     extends ConsumerState<FeedbackReceivedDialog> {
   _navigateHome() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => HomeScreen(),
-      ),
-    );
+    AutoRouter.of(context).push(const MainRoute());
   }
 
   @override

--- a/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
+++ b/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
@@ -19,7 +19,7 @@ class FeedbackReceivedDialog extends ConsumerStatefulWidget {
 class _FeedbackReceivedDialogState
     extends ConsumerState<FeedbackReceivedDialog> {
   _navigateHome() {
-    AutoRouter.of(context).push(const MainRoute());
+    AutoRouter.of(context).popUntilRoot();
   }
 
   @override

--- a/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
+++ b/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
@@ -46,11 +46,11 @@ class _FeedbackReceivedDialogState
     final regenerateButtonText = isLoading ? 'Generating...' : 'Generate Again';
 
     return AlertDialog(
-      title: TypeSetting(
+      title: const TypeSetting(
         'Thank you for the feedback!',
         variant: TextVariants.headlineLarge,
       ),
-      content: TypeSetting(
+      content: const TypeSetting(
         'We have returned the coin to you. What do you want to do next?',
       ),
       actions: [

--- a/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
+++ b/mobile/lib/app/Feedback/widgets/feedback_received_dialog.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Feedback/widgets/feedback_received_dialog_controller.dart';
 import 'package:mobile/app/Flashcard/application/flashcard_providers.dart';
-import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/components/button.dart';
 import 'package:mobile/utils/async_value_ui.dart';

--- a/mobile/lib/app/Flashcard/application/flashcard_mixin.dart
+++ b/mobile/lib/app/Flashcard/application/flashcard_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +8,7 @@ import 'package:mobile/app/Flashcard/domain/scanPhotoPayload/scan_photo_payload.
 import 'package:mobile/app/Flashcard/presentation/flashcard_screen.dart';
 import 'package:mobile/app/ObjectsOnImage/domain/ObjectOnImage/object_on_image.dart';
 import 'package:mobile/app/ObjectsOnImage/presentation/objects_on_image_screen.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/utils/either.dart';
 
 mixin FlashcardMixin {
@@ -63,12 +65,7 @@ mixin FlashcardMixin {
     if (result.isRight) {
       flashcardServiceNotifier.openFlashcard(result.right!);
 
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => const FlashcardScreen(),
-        ),
-      );
+      AutoRouter.of(context).push(const FlashcardRoute());
     } else {
       final scanPhotoPayload = result.left;
       final objectsOnImage =
@@ -76,13 +73,10 @@ mixin FlashcardMixin {
 
       objectsOnImage.sort((a, b) => b.score.compareTo(a.score));
 
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => ObjectsOnImageScreen(
-            objectsOnImage: objectsOnImage,
-            scanPhotoPayload: scanPhotoPayload,
-          ),
+      AutoRouter.of(context).push(
+        ObjectsOnImageRoute(
+          objectsOnImage: objectsOnImage,
+          scanPhotoPayload: scanPhotoPayload,
         ),
       );
     }

--- a/mobile/lib/app/Flashcard/components/dislike_button.dart
+++ b/mobile/lib/app/Flashcard/components/dislike_button.dart
@@ -1,8 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mobile/app/Feedback/presentation/feedback_screen.dart';
 import 'package:mobile/app/Flashcard/application/flashcard_service.dart';
 import 'package:mobile/app/Flashcard/widgets/SecondNegativeFeedbackDialog/second_negative_feedback_dialog.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/components/button.dart';
 
 class DislikeButton extends ConsumerWidget {
@@ -21,10 +22,7 @@ class DislikeButton extends ConsumerWidget {
       return;
     }
 
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (context) => const FeedbackScreen()),
-    );
+    AutoRouter.of(context).push(const FeedbackRoute());
   }
 
   @override

--- a/mobile/lib/app/Flashcard/widgets/FlashcardAppBar/flashcard_app_bar.dart
+++ b/mobile/lib/app/Flashcard/widgets/FlashcardAppBar/flashcard_app_bar.dart
@@ -1,7 +1,7 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile/app/Flashcard/components/dislike_button.dart';
 import 'package:mobile/app/Flashcard/widgets/FlashcardAppBar/flashcard_app_bar_controller.dart';
-import 'package:mobile/app/Home/presentation/home.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/components/button.dart';
@@ -14,12 +14,8 @@ class FlashcardAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       leading: Button(
         variat: ButtonVariant.icon,
-        onPressed: () => Navigator.push(
-          context,
-          MaterialPageRoute(builder: (context) => HomeScreen()),
-        ),
-        icon: Icons.arrow_back,
-      ),
+        onPressed: () => AutoRouter.of(context).maybePop(), 
+        icon: Icons.arrow_back,),
       actions: [
         Padding(
           padding: const EdgeInsets.only(right: 16),

--- a/mobile/lib/app/Flashcard/widgets/FlashcardAppBar/flashcard_app_bar.dart
+++ b/mobile/lib/app/Flashcard/widgets/FlashcardAppBar/flashcard_app_bar.dart
@@ -14,7 +14,7 @@ class FlashcardAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       leading: Button(
         variat: ButtonVariant.icon,
-        onPressed: () => AutoRouter.of(context).maybePop(), 
+        onPressed: () => AutoRouter.of(context).popUntilRoot(), 
         icon: Icons.arrow_back,),
       actions: [
         Padding(

--- a/mobile/lib/app/Flashcard/widgets/SecondNegativeFeedbackDialog/second_negative_feedback_dialog.dart
+++ b/mobile/lib/app/Flashcard/widgets/SecondNegativeFeedbackDialog/second_negative_feedback_dialog.dart
@@ -1,8 +1,8 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Flashcard/application/flashcard_providers.dart';
 import 'package:mobile/app/Flashcard/widgets/SecondNegativeFeedbackDialog/second_negative_feedback_dialog_controller.dart';
-import 'package:mobile/app/Home/presentation/home.dart';
 import 'package:mobile/components/button.dart';
 import 'package:mobile/components/dialogs.dart';
 import 'package:mobile/utils/async_value_ui.dart';
@@ -21,10 +21,7 @@ class SecondNegativeFeedbackDialog extends ConsumerWidget {
         ref.invalidate(findAllFlashcardsProvider);
 
         if (isFlashcardDeleted) {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (context) => HomeScreen()),
-          );
+          AutoRouter.of(context).popUntilRoot();
         }
       });
     });

--- a/mobile/lib/app/Home/components/SetQuickAction/set_quick_action.dart
+++ b/mobile/lib/app/Home/components/SetQuickAction/set_quick_action.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Home/components/SetQuickAction/set_quick_action_list_item.dart';
-import 'package:mobile/app/Profile/presentation/profile_screen.dart';
+import 'package:mobile/app/Layout/widgets/bottom_navigation.dart';
+import 'package:mobile/app/Main/application/main_provider.dart';
 import 'package:mobile/app/Profile/widgets/SetsGrid/sets_grid_controller.dart';
 import 'package:mobile/app/Set/application/set_provider.dart';
 import 'package:mobile/shared/models/Pagination/pagination.dart';
@@ -12,7 +13,7 @@ class SetQuickAction extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sets = ref.watch(
-      findAllSetsProvider(Pagination()),
+      findAllSetsProvider(const Pagination()),
     );
 
     return sets.when(
@@ -22,19 +23,13 @@ class SetQuickAction extends ConsumerWidget {
             data.result.isEmpty ? null : 'Number of sets: ${data.totalItems}',
         onTap: data.result.isNotEmpty
             ? () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => ProfileScreen(
-                      initialTabIndex: 1,
-                    ),
-                  ),
-                );
+                ref.read(currentTabIndexProvider.notifier).state =
+                    CurrentScreen.profile.value;
               }
             : SetsGridController.showSetFormBottomSheet(context),
       ),
-      loading: () => SetQuickActionListItem('Loading...'),
-      error: (error, _) => SetQuickActionListItem(
+      loading: () => const SetQuickActionListItem('Loading...'),
+      error: (error, _) => const SetQuickActionListItem(
         'Quick action temporary unavailable. Please try again later.',
       ),
     );

--- a/mobile/lib/app/Home/presentation/home.dart
+++ b/mobile/lib/app/Home/presentation/home.dart
@@ -6,8 +6,6 @@ import 'package:mobile/app/Flashcard/data/dto/flashcard_dto.dart';
 import 'package:mobile/app/Home/widgets/flash_cards_list.dart';
 import 'package:mobile/app/Home/widgets/home_app_title.dart';
 import 'package:mobile/app/Home/widgets/quick_actions.dart';
-import 'package:mobile/app/Layout/presentation/layout.dart';
-import 'package:mobile/app/Layout/widgets/bottom_navigation.dart';
 import 'package:mobile/app/Set/application/set_provider.dart';
 import 'package:mobile/app/Wallet/application/wallet_providers.dart';
 import 'package:mobile/atoms/type_setting.dart';
@@ -23,68 +21,70 @@ class HomeScreen extends ConsumerWidget {
       const FindAllFlashcardsDTO(pagination: Pagination(limit: 10)),
     ));
 
-    return Layout(
-      RefreshIndicator(
-        onRefresh: () => Future.sync(() {
-          ref.invalidate(getWalletBalanceProvider);
-          ref.invalidate(findAllSetsProvider);
-          ref.invalidate(findAllFlashcardsProvider);
-        }),
-        child: SizedBox(
-          height: double.infinity,
-          child: SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                HomeAppTitle(flashcards: flashcards),
-                const SizedBox(
-                  height: 24,
-                ),
-                const QuickActions(),
-                const SizedBox(
-                  height: 24,
-                ),
-                flashcards.when(
-                  skipLoadingOnRefresh: false,
-                  data: (flashcards) => Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      if (flashcards.result.isNotEmpty)
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            const TypeSetting(
-                              'Your latest scans',
-                              variant: TextVariants.headlineMedium,
-                            ),
-                            const SizedBox(
-                              height: 12,
-                            ),
-                          ],
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: RefreshIndicator(
+          onRefresh: () => Future.sync(() {
+            ref.invalidate(getWalletBalanceProvider);
+            ref.invalidate(findAllSetsProvider);
+            ref.invalidate(findAllFlashcardsProvider);
+          }),
+          child: SizedBox(
+            height: double.infinity,
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  HomeAppTitle(flashcards: flashcards),
+                  const SizedBox(
+                    height: 24,
+                  ),
+                  const QuickActions(),
+                  const SizedBox(
+                    height: 24,
+                  ),
+                  flashcards.when(
+                    skipLoadingOnRefresh: false,
+                    data: (flashcards) => Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        if (flashcards.result.isNotEmpty)
+                          const Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              TypeSetting(
+                                'Your latest scans',
+                                variant: TextVariants.headlineMedium,
+                              ),
+                              SizedBox(
+                                height: 12,
+                              ),
+                            ],
+                          ),
+                        FlashCardsList(
+                          flashCards: flashcards.result,
                         ),
-                      FlashCardsList(
-                        flashCards: flashcards.result,
-                      ),
-                    ],
-                  ),
-                  error: (error, _) => const Center(
-                    child: TypeSetting(
-                      "Oops! An error occurred while loading your latest scans. But don't worry, we're on it! Try again later.",
-                      style: TextStyle(color: Colors.grey),
-                      textAlign: TextAlign.center,
+                      ],
                     ),
-                  ),
-                  loading: () => const Center(
-                    child: CircularProgressIndicator(),
-                  ),
-                )
-              ],
+                    error: (error, _) => const Center(
+                      child: TypeSetting(
+                        "Oops! An error occurred while loading your latest scans. But don't worry, we're on it! Try again later.",
+                        style: TextStyle(color: Colors.grey),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    loading: () => const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  )
+                ],
+              ),
             ),
           ),
         ),
       ),
-      currentScreen: CurrentScreens.home.value,
     );
   }
 }

--- a/mobile/lib/app/Home/widgets/FlashcardListItem/flashcard_list_item_controller.dart
+++ b/mobile/lib/app/Home/widgets/FlashcardListItem/flashcard_list_item_controller.dart
@@ -1,13 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile/app/Flashcard/presentation/flashcard_screen.dart';
+import 'package:mobile/app_router.dart';
 
 class FlashCardItemController {
   static void redirectToFlashCardScreen(BuildContext context) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => const FlashcardScreen(),
-      ),
-    );
+    AutoRouter.of(context).push(const FlashcardRoute());
   }
 }

--- a/mobile/lib/app/Home/widgets/flash_cards_list.dart
+++ b/mobile/lib/app/Home/widgets/flash_cards_list.dart
@@ -1,27 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Flashcard/domain/card/card.dart';
 import 'package:mobile/app/Home/widgets/FlashcardListItem/flashcard_list_item.dart';
-import 'package:mobile/app/Profile/presentation/profile_screen.dart';
+import 'package:mobile/app/Layout/widgets/bottom_navigation.dart';
+import 'package:mobile/app/Main/application/main_provider.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 
-class FlashCardsList extends StatefulWidget {
+class FlashCardsList extends ConsumerStatefulWidget {
   const FlashCardsList({super.key, required this.flashCards});
 
   final List<FlashCard> flashCards;
 
   @override
-  State<FlashCardsList> createState() => _FlashCardsListState();
+  ConsumerState<FlashCardsList> createState() => _FlashCardsListState();
 }
 
-class _FlashCardsListState extends State<FlashCardsList> {
+class _FlashCardsListState extends ConsumerState<FlashCardsList> {
   void redirectToProfileScreen() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => const ProfileScreen(),
-      ),
-    );
+    ref.read(currentTabIndexProvider.notifier).state = CurrentScreen.profile.value;
   }
 
   @override

--- a/mobile/lib/app/Home/widgets/quick_actions.dart
+++ b/mobile/lib/app/Home/widgets/quick_actions.dart
@@ -10,28 +10,28 @@ class QuickActions extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
+    return const Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const TypeSetting(
+        TypeSetting(
           "Quick actions",
           variant: TextVariants.headlineMedium,
           style: TextStyle(
             fontWeight: FontWeight.bold,
           ),
         ),
-        const SizedBox(
+        SizedBox(
           height: 12,
         ),
-        const FlashcardQuickAction(),
-        const SizedBox(
+        FlashcardQuickAction(),
+        SizedBox(
           height: 12,
         ),
-        const SetQuickAction(),
-        const SizedBox(
+        SetQuickAction(),
+        SizedBox(
           height: 12,
         ),
-        const QuizQuickAction()
+        QuizQuickAction()
       ],
     );
   }

--- a/mobile/lib/app/Layout/components/not_enough_coins_dialog.dart
+++ b/mobile/lib/app/Layout/components/not_enough_coins_dialog.dart
@@ -1,5 +1,7 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile/app/Wallet/presentation/wallet_screen.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 
@@ -22,9 +24,7 @@ class NotEnoughCoinsDialog extends StatelessWidget {
             'Cancel',
             style: TextStyle(color: AppColors.primary),
           ),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
+          onPressed: () => AutoRouter.of(context).maybePop(),
         ),
         ElevatedButton(
           child: const TypeSetting(
@@ -32,11 +32,7 @@ class NotEnoughCoinsDialog extends StatelessWidget {
             style: TextStyle(color: AppColors.primary),
           ),
           onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const WalletScreen(),
-              ),
-            );
+            AutoRouter.of(context).push(const WalletRoute());
           },
         ),
       ],

--- a/mobile/lib/app/Layout/components/not_enough_coins_dialog.dart
+++ b/mobile/lib/app/Layout/components/not_enough_coins_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile/app/Wallet/presentation/wallet_screen.dart';
 import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';

--- a/mobile/lib/app/Layout/presentation/layout.dart
+++ b/mobile/lib/app/Layout/presentation/layout.dart
@@ -27,13 +27,6 @@ class Layout extends StatelessWidget {
         ),
       ),
       backgroundColor: Colors.black,
-      bottomNavigationBar: BottomNavigation(
-        screens: screens,
-        currentScreen: currentScreen,
-      ),
-      floatingActionButton: const FloatingButton(),
-      floatingActionButtonLocation:
-          FloatingActionButtonLocation.miniCenterDocked,
     );
   }
 }

--- a/mobile/lib/app/Layout/presentation/layout.dart
+++ b/mobile/lib/app/Layout/presentation/layout.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mobile/app/Home/presentation/home.dart';
-import 'package:mobile/app/Layout/widgets/bottom_navigation.dart';
-import 'package:mobile/app/Layout/widgets/floating_button.dart';
 import 'package:mobile/app/Profile/presentation/profile_screen.dart';
 
 const screens = [

--- a/mobile/lib/app/Layout/widgets/bottom_navigation.dart
+++ b/mobile/lib/app/Layout/widgets/bottom_navigation.dart
@@ -1,43 +1,32 @@
 import 'package:flutter/material.dart';
 
-enum CurrentScreens {
+enum CurrentScreen {
   home(0),
   profile(1);
 
-  const CurrentScreens(this.value);
+  const CurrentScreen(this.value);
 
   final int value;
 }
 
-class BottomNavigation extends StatefulWidget {
+class BottomNavigation extends StatelessWidget {
   const BottomNavigation({
     super.key,
-    this.currentScreen = 0,
-    required this.screens,
+    this.currentScreen = CurrentScreen.home,
+    required this.onNewScreenSelected,
   });
 
-  final int currentScreen;
-  final List<Widget> screens;
-
-  @override
-  State<BottomNavigation> createState() => _BottomNavigationState();
-}
-
-class _BottomNavigationState extends State<BottomNavigation> {
-  void _navigate(int index) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => widget.screens[index],
-      ),
-    );
-  }
+  final CurrentScreen currentScreen;
+  final void Function(CurrentScreen) onNewScreenSelected;
 
   @override
   Widget build(BuildContext context) {
     return BottomNavigationBar(
       items: const [
-        BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.home),
+          label: 'Home',
+        ),
         BottomNavigationBarItem(
           icon: Icon(Icons.account_circle),
           label: 'Profile',
@@ -46,8 +35,12 @@ class _BottomNavigationState extends State<BottomNavigation> {
       selectedItemColor: Colors.white,
       unselectedItemColor: Colors.grey[500],
       backgroundColor: const Color.fromRGBO(48, 48, 48, 1),
-      onTap: _navigate,
-      currentIndex: widget.currentScreen,
+      onTap: (index) {
+        onNewScreenSelected(
+          CurrentScreen.values.where((screen) => screen.value == index).first,
+        );
+      },
+      currentIndex: currentScreen.value,
     );
   }
 }

--- a/mobile/lib/app/Layout/widgets/floating_button.dart
+++ b/mobile/lib/app/Layout/widgets/floating_button.dart
@@ -3,23 +3,14 @@ import 'package:mobile/atoms/colors.dart';
 import 'AddBottomSheet/add_bottom_sheet.dart';
 
 class FloatingButton extends StatelessWidget {
-  const FloatingButton({super.key});
+  const FloatingButton({super.key, required this.onPressed});
 
-  void _handleAdd(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      clipBehavior: Clip.hardEdge,
-      builder: (context) => const AddBottomSheet(),
-    );
-  }
-
+  final VoidCallback onPressed;
+  
   @override
   Widget build(BuildContext context) {
     return FloatingActionButton(
-      onPressed: () {
-        _handleAdd(context);
-      },
+      onPressed: onPressed,
       backgroundColor: AppColors.primary,
       foregroundColor: Colors.black,
       child: const Icon(Icons.add),

--- a/mobile/lib/app/Layout/widgets/floating_button.dart
+++ b/mobile/lib/app/Layout/widgets/floating_button.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:mobile/atoms/colors.dart';
-import 'AddBottomSheet/add_bottom_sheet.dart';
 
 class FloatingButton extends StatelessWidget {
   const FloatingButton({super.key, required this.onPressed});
 
   final VoidCallback onPressed;
-  
+
   @override
   Widget build(BuildContext context) {
     return FloatingActionButton(

--- a/mobile/lib/app/Main/application/main_provider.dart
+++ b/mobile/lib/app/Main/application/main_provider.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final currentTabIndexProvider = StateProvider<int>((ref) => 0);

--- a/mobile/lib/app/Main/presentation/main_screen.dart
+++ b/mobile/lib/app/Main/presentation/main_screen.dart
@@ -9,8 +9,6 @@ import 'package:mobile/app/Profile/presentation/profile_screen.dart';
 import '../../Layout/widgets/floating_button.dart';
 import '../application/main_provider.dart';
 
-
-
 @RoutePage()
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key});

--- a/mobile/lib/app/Main/presentation/main_screen.dart
+++ b/mobile/lib/app/Main/presentation/main_screen.dart
@@ -1,0 +1,77 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile/app/Home/presentation/home.dart';
+import 'package:mobile/app/Layout/widgets/AddBottomSheet/add_bottom_sheet.dart';
+import 'package:mobile/app/Layout/widgets/bottom_navigation.dart';
+import 'package:mobile/app/Profile/presentation/profile_screen.dart';
+
+import '../../Layout/widgets/floating_button.dart';
+import '../application/main_provider.dart';
+
+
+
+@RoutePage()
+class MainScreen extends ConsumerStatefulWidget {
+  const MainScreen({super.key});
+
+  @override
+  ConsumerState<MainScreen> createState() => _MainTabNavigatorState();
+}
+
+class _MainTabNavigatorState extends ConsumerState<MainScreen> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  final List<Widget> _pages = const [
+    HomeScreen(),
+    ProfileScreen(),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: _pages.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentIndex = ref.watch(currentTabIndexProvider);
+
+    ref.listen<int>(currentTabIndexProvider, (previousIndex, newIndex) {
+      if (newIndex != _tabController.index) {
+        _tabController.index = newIndex;
+      }
+    });
+
+    return Scaffold(
+      body: TabBarView(
+        physics: const NeverScrollableScrollPhysics(),
+        controller: _tabController,
+        children: _pages,
+      ),
+      bottomNavigationBar: BottomNavigation(
+        currentScreen: CurrentScreen.values[currentIndex],
+        onNewScreenSelected: (newScreen) {
+          ref.read(currentTabIndexProvider.notifier).state = newScreen.value;
+        },
+      ),
+      floatingActionButton: FloatingButton(onPressed: _showAddBottomSheet),
+      floatingActionButtonLocation: FloatingActionButtonLocation.miniCenterDocked,
+    );
+  }
+
+  void _showAddBottomSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      clipBehavior: Clip.hardEdge,
+      builder: (context) => const AddBottomSheet(),
+    );
+  }
+}

--- a/mobile/lib/app/ObjectsOnImage/presentation/objects_on_image_screen.dart
+++ b/mobile/lib/app/ObjectsOnImage/presentation/objects_on_image_screen.dart
@@ -49,14 +49,14 @@ class ObjectsOnImageScreen extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            TypeSetting(
+            const TypeSetting(
               'Select an object',
               variant: TextVariants.headlineLarge,
             ),
             const SizedBox(
               height: 16,
             ),
-            TypeSetting(
+            const TypeSetting(
               'We’ve a detected a few objects on your photo. Please select one item and we’ll generate the flashcard for it.',
               style: TextStyle(color: AppColors.lightGrey),
             ),

--- a/mobile/lib/app/ObjectsOnImage/presentation/objects_on_image_screen.dart
+++ b/mobile/lib/app/ObjectsOnImage/presentation/objects_on_image_screen.dart
@@ -1,18 +1,20 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Flashcard/application/flashcard_providers.dart';
 import 'package:mobile/app/Flashcard/domain/scanPhotoPayload/scan_photo_payload.dart';
-import 'package:mobile/app/Flashcard/presentation/flashcard_screen.dart';
 import 'package:mobile/app/ObjectsOnImage/domain/ObjectOnImage/object_on_image.dart';
 import 'package:mobile/app/Layout/presentation/layout.dart';
 import 'package:mobile/app/ObjectsOnImage/presentation/objects_on_image_screen_controller.dart';
 import 'package:mobile/app/ObjectsOnImage/widgets/NoDesiredObject/no_desired_object.dart';
 import 'package:mobile/app/ObjectsOnImage/widgets/object_list_item.dart';
 import 'package:mobile/app/Wallet/application/wallet_providers.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/utils/async_value_ui.dart';
 
+@RoutePage()
 class ObjectsOnImageScreen extends ConsumerWidget {
   const ObjectsOnImageScreen({
     super.key,
@@ -33,12 +35,7 @@ class ObjectsOnImageScreen extends ConsumerWidget {
         ref.invalidate(findAllFlashcardsProvider);
         ref.invalidate(getWalletBalanceProvider);
 
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const FlashcardScreen(),
-          ),
-        );
+        AutoRouter.of(context).push(const FlashcardRoute());
       });
     });
 

--- a/mobile/lib/app/ObjectsOnImage/widgets/NoDesiredObjectDialog/no_desired_obect_dialog.dart
+++ b/mobile/lib/app/ObjectsOnImage/widgets/NoDesiredObjectDialog/no_desired_obect_dialog.dart
@@ -1,5 +1,6 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile/app/Home/presentation/home.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 
@@ -9,22 +10,19 @@ class NoDesiredObectDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: TypeSetting(
+      title: const TypeSetting(
         'Oh no...',
         variant: TextVariants.headlineLarge,
       ),
-      content: TypeSetting(
+      content: const TypeSetting(
         'We’re sorry that we couldn’t recognize your desired object. Please try another photo instead. Don’t worry, you were not charged for this image',
       ),
       actions: [
         TextButton(
           onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => HomeScreen()),
-            );
+            AutoRouter.of(context).push(const MainRoute());
           },
-          child: TypeSetting(
+          child: const TypeSetting(
             'Close',
             style: TextStyle(
               color: AppColors.primary,

--- a/mobile/lib/app/ObjectsOnImage/widgets/NoDesiredObjectDialog/no_desired_obect_dialog.dart
+++ b/mobile/lib/app/ObjectsOnImage/widgets/NoDesiredObjectDialog/no_desired_obect_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 
@@ -20,7 +19,7 @@ class NoDesiredObectDialog extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: () {
-            AutoRouter.of(context).push(const MainRoute());
+            AutoRouter.of(context).popUntilRoot();
           },
           child: const TypeSetting(
             'Close',

--- a/mobile/lib/app/Profile/presentation/profile_screen.dart
+++ b/mobile/lib/app/Profile/presentation/profile_screen.dart
@@ -1,8 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mobile/app/Layout/presentation/layout.dart';
-import 'package:mobile/app/Layout/widgets/bottom_navigation.dart';
 import 'package:mobile/app/Profile/widgets/ProfileAppBar/profile_app_bar.dart';
 import 'package:mobile/app/Profile/widgets/SetsGrid/sets_grid.dart';
 import 'package:mobile/app/Profile/widgets/flashcards_grid.dart';
@@ -41,14 +39,20 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Layout(
-      TabBarView(
-        controller: _tabController,
-        children: const [FlashcardsGrid(), SetsGrid()],
-      ),
-      currentScreen: CurrentScreens.profile.value,
-      appBar: ProfileAppBar(
-        _tabController,
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            ProfileAppBar(_tabController),
+            Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: const [FlashcardsGrid(), SetsGrid()],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/app/Profile/widgets/ProfileAppBar/profile_app_bar.dart
+++ b/mobile/lib/app/Profile/widgets/ProfileAppBar/profile_app_bar.dart
@@ -5,7 +5,7 @@ import 'package:mobile/app/Profile/widgets/ProfileAppBar/profile_app_bar_control
 import 'package:mobile/app/Profile/widgets/ProfileAppTitle/profile_app_title.dart';
 import 'package:mobile/utils/maybe.dart';
 
-class ProfileAppBar extends ConsumerWidget implements PreferredSizeWidget {
+class ProfileAppBar extends ConsumerWidget {
   const ProfileAppBar(this.tabController, {super.key});
 
   final TabController tabController;
@@ -18,30 +18,31 @@ class ProfileAppBar extends ConsumerWidget implements PreferredSizeWidget {
         .map<ImageProvider>((photo) => NetworkImage(photo!))
         .getOrElse(const AssetImage('assets/images/account.png'));
 
-    return AppBar(
-      automaticallyImplyLeading: false,
-      title: const ProfileAppTitle(),
-      actions: [
-        Padding(
-          padding: const EdgeInsets.only(right: 16),
-          child: GestureDetector(
-            onTap: ProfileAppBarController.showSettingsBottomSheet(context),
-            child: CircleAvatar(
-              backgroundImage: avatar,
-            ),
-          ),
-        )
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const ProfileAppTitle(),
+            Padding(
+              padding: const EdgeInsets.only(right: 16),
+              child: GestureDetector(
+                onTap: ProfileAppBarController.showSettingsBottomSheet(context),
+                child: CircleAvatar(
+                  backgroundImage: avatar,
+                ),
+              ),
+            )
+          ],
+        ),
+        TabBar(
+          tabs: const [
+            Tab(text: 'Flashcards'),
+            Tab(text: 'Sets'),
+          ],
+          controller: tabController,
+        ),
       ],
-      bottom: TabBar(
-        tabs: const [
-          Tab(text: 'Flashcards'),
-          Tab(text: 'Sets'),
-        ],
-        controller: tabController,
-      ),
     );
   }
-
-  @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight * 1.8);
 }

--- a/mobile/lib/app/Profile/widgets/ProfileAppTitle/profile_app_title_controller.dart
+++ b/mobile/lib/app/Profile/widgets/ProfileAppTitle/profile_app_title_controller.dart
@@ -1,13 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile/app/Wallet/presentation/wallet_screen.dart';
+import 'package:mobile/app_router.dart';
 
 class ProfileAppTitleController {
   static void Function() redirectToWalletScreen(BuildContext context) => () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const WalletScreen(),
-          ),
-        );
+        AutoRouter.of(context).push(const WalletRoute());
       };
 }

--- a/mobile/lib/app/Profile/widgets/ProfileManageAccount/profile_manage_account_controller.dart
+++ b/mobile/lib/app/Profile/widgets/ProfileManageAccount/profile_manage_account_controller.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mobile/app/Profile/widgets/DeleteDataDialog/delete_data_dialog.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 class ProfileManageAccountController {
   static void Function() showSetsBottomSheet(BuildContext context) => () {

--- a/mobile/lib/app/Profile/widgets/set_form.dart
+++ b/mobile/lib/app/Profile/widgets/set_form.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,8 +6,8 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:mobile/app/Set/application/set_provider.dart';
 import 'package:mobile/app/Set/domain/set.dart';
 import 'package:mobile/app/Set/application/set_service.dart';
-import 'package:mobile/app/Set/presentation/set_screen.dart';
 import 'package:mobile/app/Set/presentation/set_screen_controller.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/utils/async_value_ui.dart';
@@ -39,12 +40,7 @@ class SetForm extends ConsumerWidget {
         ref.invalidate(findNotStudiedSetsProvider);
 
         if (set == null) {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const SetScreen(),
-            ),
-          );
+          AutoRouter.of(context).push(const SetRoute());
         }
       });
     });

--- a/mobile/lib/app/Profile/widgets/set_grid_item.dart
+++ b/mobile/lib/app/Profile/widgets/set_grid_item.dart
@@ -1,9 +1,10 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Set/application/set_service.dart';
 import 'package:mobile/app/Set/components/set_preview.dart';
 import 'package:mobile/app/Set/domain/set.dart';
-import 'package:mobile/app/Set/presentation/set_screen.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/utils/plularize.dart';
 import 'package:timeago/timeago.dart' as timeago;
@@ -22,10 +23,7 @@ class _SetGridItemState extends ConsumerState<SetGridItem> {
   _navigateToSetScreen() {
     ref.read(setServiceProvider.notifier).openSet(widget.set);
 
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (context) => const SetScreen()),
-    );
+    AutoRouter.of(context).push(const SetRoute());
   }
 
   @override

--- a/mobile/lib/app/Profile/widgets/settings_list.dart
+++ b/mobile/lib/app/Profile/widgets/settings_list.dart
@@ -1,8 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Auth/data/auth_repository.dart';
 import 'package:mobile/app/Profile/widgets/ProfileManageAccount/profile_manage_account.dart';
-import 'package:mobile/app/Wallet/presentation/wallet_screen.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/type_setting.dart';
 
 class SettingsList extends ConsumerWidget {
@@ -18,12 +19,7 @@ class SettingsList extends ConsumerWidget {
         ListTile(
           key: const Key('wallet'),
           onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => const WalletScreen(),
-              ),
-            );
+            AutoRouter.of(context).push(const WalletRoute());
           },
           title: const TypeSetting('Wallet'),
         ),

--- a/mobile/lib/app/Quiz/presentation/QuizScreen/quiz_screen.dart
+++ b/mobile/lib/app/Quiz/presentation/QuizScreen/quiz_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Flashcard/application/flashcard_providers.dart';
@@ -6,13 +7,14 @@ import 'package:mobile/app/Flashcard/data/dto/flashcard_dto.dart';
 import 'package:mobile/app/Layout/presentation/layout.dart';
 import 'package:mobile/app/Quiz/domain/result.dart';
 import 'package:mobile/app/Quiz/presentation/QuizScreen/quiz_screen_controller.dart';
-import 'package:mobile/app/Quiz/presentation/result_screen.dart';
 import 'package:mobile/app/Set/application/set_service.dart';
+import 'package:mobile/app_router.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/components/full_screen_image.dart';
 import 'package:mobile/shared/models/Pagination/pagination.dart';
 import 'package:mobile/shared/models/ServerError/server_error.dart';
 
+@RoutePage()
 class QuizScreen extends ConsumerStatefulWidget {
   const QuizScreen({super.key});
 
@@ -44,14 +46,7 @@ class _QuizScreenState extends ConsumerState<QuizScreen> {
     }
 
     if (_results.length == flashcards.length) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => ResultScreen(
-            results: _results,
-          ),
-        ),
-      );
+      AutoRouter.of(context).push(ResultRoute(results: _results));
     }
   }
 

--- a/mobile/lib/app/Quiz/presentation/result_screen.dart
+++ b/mobile/lib/app/Quiz/presentation/result_screen.dart
@@ -62,7 +62,7 @@ class ResultScreen extends StatelessWidget {
             child: ElevatedButton(
               onPressed: () => AutoRouter.of(context).popUntilRoot(),
               child: const TypeSetting(
-                'Go to the Home',
+                'Back to home',
                 style: TextStyle(color: AppColors.primary),
               ),
             ),

--- a/mobile/lib/app/Quiz/presentation/result_screen.dart
+++ b/mobile/lib/app/Quiz/presentation/result_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:mobile/app/Layout/presentation/layout.dart';
@@ -6,6 +7,7 @@ import 'package:mobile/atoms/colors.dart';
 import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/widgets/list_item.dart';
 
+@RoutePage()
 class ResultScreen extends StatelessWidget {
   const ResultScreen({super.key, required this.results});
 
@@ -52,7 +54,19 @@ class ResultScreen extends StatelessWidget {
                   : AppColors.error,
             ),
             itemCount: results.length,
-          )
+          ),
+          const SizedBox(
+            height: 24,
+          ),
+          Center(
+            child: ElevatedButton(
+              onPressed: () => AutoRouter.of(context).popUntilRoot(),
+              child: const TypeSetting(
+                'Go to the Home',
+                style: TextStyle(color: AppColors.primary),
+              ),
+            ),
+          ),
         ],
       ),
     ));

--- a/mobile/lib/app/Set/application/set_provider.dart
+++ b/mobile/lib/app/Set/application/set_provider.dart
@@ -14,7 +14,7 @@ final findInProgressSetsProvider = FutureProvider.autoDispose((ref) async {
   final quizStatuses =
       await ref.watch(quizRepositoryProvider).findAllStatuses();
 
-  final sets = await ref.watch(setRepositoryProvider).findAll(Pagination());
+  final sets = await ref.watch(setRepositoryProvider).findAll(const Pagination());
 
   return sets.result
       .where(
@@ -33,7 +33,7 @@ final findNotStudiedSetsProvider = FutureProvider.autoDispose((ref) async {
   final quizStatuses =
       await ref.watch(quizRepositoryProvider).findAllStatuses();
 
-  final sets = await ref.watch(setRepositoryProvider).findAll(Pagination());
+  final sets = await ref.watch(setRepositoryProvider).findAll(const Pagination());
 
   return sets.result
       .where(

--- a/mobile/lib/app/Set/components/DeleteActionItem/delete_action_item.dart
+++ b/mobile/lib/app/Set/components/DeleteActionItem/delete_action_item.dart
@@ -1,6 +1,6 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mobile/app/Profile/presentation/profile_screen.dart';
 import 'package:mobile/app/Set/application/set_service.dart';
 import 'package:mobile/app/Set/components/DeleteActionItem/delete_action_item_controller.dart';
 import 'package:mobile/app/Set/presentation/set_screen_controller.dart';
@@ -21,13 +21,7 @@ class DeleteActionItem extends ConsumerWidget {
 
       state.whenData((value) {
         setsPagingController?.refresh();
-
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const ProfileScreen(initialTabIndex: 1),
-          ),
-        );
+        AutoRouter.of(context).popUntilRoot();
       });
     });
 

--- a/mobile/lib/app/Set/presentation/set_screen.dart
+++ b/mobile/lib/app/Set/presentation/set_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Layout/presentation/layout.dart';
@@ -6,6 +7,7 @@ import 'package:mobile/app/Set/application/set_service.dart';
 import 'package:mobile/app/Set/widgets/SetAppBar/set_app_bar.dart';
 import 'package:mobile/app/Set/widgets/flashcard_actions.dart';
 
+@RoutePage()
 class SetScreen extends ConsumerWidget {
   const SetScreen({super.key});
 

--- a/mobile/lib/app/Set/widgets/SetAppBar/set_app_bar_controller.dart
+++ b/mobile/lib/app/Set/widgets/SetAppBar/set_app_bar_controller.dart
@@ -1,8 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:mobile/app/Quiz/presentation/QuizScreen/quiz_screen.dart';
 import 'package:mobile/app/Set/components/quiz_flashcards_amount_warning.dart';
 import 'package:mobile/app/Set/domain/set.dart';
 import 'package:mobile/app/Set/widgets/actions_list.dart';
+import 'package:mobile/app_router.dart';
 
 const kMinimalAmountOfFlashcardsToStartQuiz = 2;
 
@@ -29,10 +30,7 @@ class SetAppBarController {
         );
       }
 
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (context) => const QuizScreen()),
-      );
+      AutoRouter.of(context).push(const QuizRoute());
     };
   }
 }

--- a/mobile/lib/app/Wallet/components/balance.dart
+++ b/mobile/lib/app/Wallet/components/balance.dart
@@ -20,7 +20,7 @@ class Balance extends StatelessWidget {
         ),
         TypeSetting(
           value.toString(),
-          style: TextStyle(color: AppColors.primary),
+          style: const TextStyle(color: AppColors.primary),
         ),
       ],
     );

--- a/mobile/lib/app/Wallet/presentation/wallet_screen.dart
+++ b/mobile/lib/app/Wallet/presentation/wallet_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile/app/Layout/presentation/layout.dart';
@@ -7,6 +8,7 @@ import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/shared/models/ServerError/server_error.dart';
 import 'package:mobile/utils/plularize.dart';
 
+@RoutePage()
 class WalletScreen extends ConsumerWidget {
   const WalletScreen({Key? key}) : super(key: key);
 

--- a/mobile/lib/app_router.dart
+++ b/mobile/lib/app_router.dart
@@ -1,9 +1,18 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:mobile/app/Feedback/presentation/feedback_screen.dart';
+import 'package:mobile/app/Flashcard/domain/scanPhotoPayload/scan_photo_payload.dart';
 import 'package:mobile/app/Flashcard/presentation/flashcard_screen.dart';
 import 'package:mobile/app/Home/presentation/home.dart';
+import 'package:mobile/app/ObjectsOnImage/domain/ObjectOnImage/object_on_image.dart';
+import 'package:mobile/app/ObjectsOnImage/presentation/objects_on_image_screen.dart';
 import 'package:mobile/app/Profile/presentation/profile_screen.dart';
+import 'package:mobile/app/Quiz/domain/result.dart';
+import 'package:mobile/app/Quiz/presentation/QuizScreen/quiz_screen.dart';
+import 'package:mobile/app/Quiz/presentation/result_screen.dart';
+import 'package:mobile/app/Set/presentation/set_screen.dart';
+import 'package:mobile/app/Wallet/presentation/wallet_screen.dart';
 import 'package:mobile/app/Welcome/presentation/welcome_screen.dart';
 import 'package:mobile/app/Main/presentation/main_screen.dart';
 
@@ -29,6 +38,11 @@ class AppRouter extends _$AppRouter implements AutoRouteGuard {
         AutoRoute(page: MainRoute.page, initial: true),
         AutoRoute(page: ProfileRoute.page),
         AutoRoute(page: WelcomeRoute.page),
-        AutoRoute(page: FlashcardRoute.page)
+        AutoRoute(page: FlashcardRoute.page),
+        AutoRoute(page: WalletRoute.page),
+        AutoRoute(page: FeedbackRoute.page),
+        AutoRoute(page: SetRoute.page),
+        AutoRoute(page: QuizRoute.page),
+        AutoRoute(page: ResultRoute.page)
       ];
 }

--- a/mobile/lib/app_router.dart
+++ b/mobile/lib/app_router.dart
@@ -5,6 +5,7 @@ import 'package:mobile/app/Flashcard/presentation/flashcard_screen.dart';
 import 'package:mobile/app/Home/presentation/home.dart';
 import 'package:mobile/app/Profile/presentation/profile_screen.dart';
 import 'package:mobile/app/Welcome/presentation/welcome_screen.dart';
+import 'package:mobile/app/Main/presentation/main_screen.dart';
 
 part 'app_router.gr.dart';
 
@@ -25,7 +26,7 @@ class AppRouter extends _$AppRouter implements AutoRouteGuard {
 
   @override
   List<AutoRoute> get routes => [
-        AutoRoute(page: HomeRoute.page, initial: true),
+        AutoRoute(page: MainRoute.page, initial: true),
         AutoRoute(page: ProfileRoute.page),
         AutoRoute(page: WelcomeRoute.page),
         AutoRoute(page: FlashcardRoute.page)

--- a/mobile/lib/app_router.gr.dart
+++ b/mobile/lib/app_router.gr.dart
@@ -15,6 +15,12 @@ abstract class _$AppRouter extends RootStackRouter {
 
   @override
   final Map<String, PageFactory> pagesMap = {
+    FeedbackRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const FeedbackScreen(),
+      );
+    },
     FlashcardRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -33,6 +39,17 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const MainScreen(),
       );
     },
+    ObjectsOnImageRoute.name: (routeData) {
+      final args = routeData.argsAs<ObjectsOnImageRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ObjectsOnImageScreen(
+          key: args.key,
+          objectsOnImage: args.objectsOnImage,
+          scanPhotoPayload: args.scanPhotoPayload,
+        ),
+      );
+    },
     ProfileRoute.name: (routeData) {
       final args = routeData.argsAs<ProfileRouteArgs>(
           orElse: () => const ProfileRouteArgs());
@@ -44,6 +61,34 @@ abstract class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    QuizRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const QuizScreen(),
+      );
+    },
+    ResultRoute.name: (routeData) {
+      final args = routeData.argsAs<ResultRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: ResultScreen(
+          key: args.key,
+          results: args.results,
+        ),
+      );
+    },
+    SetRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SetScreen(),
+      );
+    },
+    WalletRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const WalletScreen(),
+      );
+    },
     WelcomeRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -51,6 +96,20 @@ abstract class _$AppRouter extends RootStackRouter {
       );
     },
   };
+}
+
+/// generated route for
+/// [FeedbackScreen]
+class FeedbackRoute extends PageRouteInfo<void> {
+  const FeedbackRoute({List<PageRouteInfo>? children})
+      : super(
+          FeedbackRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'FeedbackRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for
@@ -96,6 +155,49 @@ class MainRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [ObjectsOnImageScreen]
+class ObjectsOnImageRoute extends PageRouteInfo<ObjectsOnImageRouteArgs> {
+  ObjectsOnImageRoute({
+    Key? key,
+    required List<ObjectOnImage> objectsOnImage,
+    required ScanPhotoPayload scanPhotoPayload,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ObjectsOnImageRoute.name,
+          args: ObjectsOnImageRouteArgs(
+            key: key,
+            objectsOnImage: objectsOnImage,
+            scanPhotoPayload: scanPhotoPayload,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ObjectsOnImageRoute';
+
+  static const PageInfo<ObjectsOnImageRouteArgs> page =
+      PageInfo<ObjectsOnImageRouteArgs>(name);
+}
+
+class ObjectsOnImageRouteArgs {
+  const ObjectsOnImageRouteArgs({
+    this.key,
+    required this.objectsOnImage,
+    required this.scanPhotoPayload,
+  });
+
+  final Key? key;
+
+  final List<ObjectOnImage> objectsOnImage;
+
+  final ScanPhotoPayload scanPhotoPayload;
+
+  @override
+  String toString() {
+    return 'ObjectsOnImageRouteArgs{key: $key, objectsOnImage: $objectsOnImage, scanPhotoPayload: $scanPhotoPayload}';
+  }
+}
+
+/// generated route for
 /// [ProfileScreen]
 class ProfileRoute extends PageRouteInfo<ProfileRouteArgs> {
   ProfileRoute({
@@ -131,6 +233,85 @@ class ProfileRouteArgs {
   String toString() {
     return 'ProfileRouteArgs{key: $key, initialTabIndex: $initialTabIndex}';
   }
+}
+
+/// generated route for
+/// [QuizScreen]
+class QuizRoute extends PageRouteInfo<void> {
+  const QuizRoute({List<PageRouteInfo>? children})
+      : super(
+          QuizRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'QuizRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [ResultScreen]
+class ResultRoute extends PageRouteInfo<ResultRouteArgs> {
+  ResultRoute({
+    Key? key,
+    required List<Result> results,
+    List<PageRouteInfo>? children,
+  }) : super(
+          ResultRoute.name,
+          args: ResultRouteArgs(
+            key: key,
+            results: results,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ResultRoute';
+
+  static const PageInfo<ResultRouteArgs> page = PageInfo<ResultRouteArgs>(name);
+}
+
+class ResultRouteArgs {
+  const ResultRouteArgs({
+    this.key,
+    required this.results,
+  });
+
+  final Key? key;
+
+  final List<Result> results;
+
+  @override
+  String toString() {
+    return 'ResultRouteArgs{key: $key, results: $results}';
+  }
+}
+
+/// generated route for
+/// [SetScreen]
+class SetRoute extends PageRouteInfo<void> {
+  const SetRoute({List<PageRouteInfo>? children})
+      : super(
+          SetRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SetRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [WalletScreen]
+class WalletRoute extends PageRouteInfo<void> {
+  const WalletRoute({List<PageRouteInfo>? children})
+      : super(
+          WalletRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'WalletRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
 }
 
 /// generated route for

--- a/mobile/lib/app_router.gr.dart
+++ b/mobile/lib/app_router.gr.dart
@@ -27,6 +27,12 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const HomeScreen(),
       );
     },
+    MainRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const MainScreen(),
+      );
+    },
     ProfileRoute.name: (routeData) {
       final args = routeData.argsAs<ProfileRouteArgs>(
           orElse: () => const ProfileRouteArgs());
@@ -71,6 +77,20 @@ class HomeRoute extends PageRouteInfo<void> {
         );
 
   static const String name = 'HomeRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [MainScreen]
+class MainRoute extends PageRouteInfo<void> {
+  const MainRoute({List<PageRouteInfo>? children})
+      : super(
+          MainRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'MainRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/mobile/lib/components/button.dart
+++ b/mobile/lib/components/button.dart
@@ -48,14 +48,14 @@ class Button extends StatelessWidget {
       case ButtonVariant.elevated:
         return ElevatedButton(
           onPressed: onPress,
-          child: child,
           style: style,
+          child: child,
         );
       case ButtonVariant.outlined:
         return OutlinedButton(
           onPressed: onPress,
-          child: child,
           style: outlinedStyle,
+          child: child,
         );
       case ButtonVariant.text:
         return TextButton(
@@ -71,7 +71,7 @@ class Button extends StatelessWidget {
           ),
         );
       default:
-        return ElevatedButton(onPressed: onPress, child: child, style: style);
+        return ElevatedButton(onPressed: onPress, style: style, child: child);
     }
   }
 }

--- a/mobile/lib/widgets/input.dart
+++ b/mobile/lib/widgets/input.dart
@@ -24,7 +24,7 @@ class Input extends StatelessWidget {
       name: name,
       validator: validator,
       decoration: InputDecoration(
-        border: OutlineInputBorder(),
+        border: const OutlineInputBorder(),
         labelText: label,
         helperText: helperText,
         suffixIcon: clearable != null && clearable!

--- a/mobile/lib/widgets/list_item.dart
+++ b/mobile/lib/widgets/list_item.dart
@@ -25,7 +25,7 @@ class ListItem extends ListTile {
     final sublabelPadding = sublabel == null
         ? const EdgeInsets.all(10)
         : const EdgeInsets.only(left: 10, right: 10);
-    final padding = contentPadding != null ? contentPadding : sublabelPadding;
+    final padding = contentPadding ?? sublabelPadding;
 
     return ListTile(
       enabled: enabled,
@@ -35,9 +35,7 @@ class ListItem extends ListTile {
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
       ),
-      leading: leading != null
-          ? leading
-          : ClipRRect(
+      leading: leading ?? ClipRRect(
               borderRadius: BorderRadius.circular(8),
               child: Image.network(
                 image ?? kStubImageUrl,


### PR DESCRIPTION
## Overview

- Avoid using Navigator for navigation between screens
- Use the Tabbar only on the Home screen but not for the nested ones

## Test cases

- Check dialogs
- Change navigation from Home or Profile screens

## Screenshots

![Simulator Screenshot - iPhone 15 Pro Max - 2024-11-13 at 19 23 15](https://github.com/user-attachments/assets/c9d86fe8-d21e-464b-8bd2-257322238075)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-11-13 at 19 23 12](https://github.com/user-attachments/assets/f3390388-aa6f-40ae-89b7-23fc4b782b01)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-11-13 at 19 23 10](https://github.com/user-attachments/assets/401ff26d-5f17-4853-8ad5-98d508718f5b)

https://github.com/user-attachments/assets/41d29afc-ea72-47fb-b40a-1bb22f238a06



## Issue

[IMB-308](https://www.notion.so/Migrate-to-app_route-instead-of-standard-Flutter-s-navigation-12575429ec6580128777c3a373f59666?pvs=4)
[IMB-336](https://www.notion.so/FE-Implement-new-router-13475429ec6580faa23aeb68f8aeb202?pvs=4)
