### PR TITLE
IMB-472: Animate navigation to sets in the profile tab

### DIFF
--- a/mobile/lib/app/Main/presentation/main_screen.dart
+++ b/mobile/lib/app/Main/presentation/main_screen.dart
@@ -54,8 +54,8 @@ class _MainTabNavigatorState extends ConsumerState<MainScreen>
         children: [
           const HomeScreen(),
           ProfileScreen(
-              key: const ValueKey('ProfileScreen'),
-              initialTabIndex: initialProfileIndex),
+            initialTabIndex: initialProfileIndex,
+          ),
         ],
       ),
       bottomNavigationBar: BottomNavigation(

--- a/mobile/lib/app/Profile/presentation/profile_screen.dart
+++ b/mobile/lib/app/Profile/presentation/profile_screen.dart
@@ -21,14 +21,23 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen>
 
   @override
   void initState() {
+    super.initState();
+
     _tabController = TabController(
       length: 2,
       animationDuration: const Duration(milliseconds: 300),
       vsync: this,
       initialIndex: widget.initialTabIndex,
     );
+  }
 
-    super.initState();
+  @override
+  void didUpdateWidget(covariant ProfileScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.initialTabIndex != _tabController.index) {
+      _tabController.animateTo(widget.initialTabIndex);
+    }
   }
 
   @override

--- a/mobile/lib/app/Profile/widgets/flashcards_grid.dart
+++ b/mobile/lib/app/Profile/widgets/flashcards_grid.dart
@@ -22,6 +22,8 @@ class _FlashcardsGridState extends ConsumerState<FlashcardsGrid> {
 
   @override
   void initState() {
+    super.initState();
+
     Future(() {
       ref
           .read(flashcardPagingControllerProvider.notifier)
@@ -30,12 +32,9 @@ class _FlashcardsGridState extends ConsumerState<FlashcardsGrid> {
 
     final findUserFlashcards =
         ref.read(profileScreenControllerProvider.notifier).findUserFlashcards;
-
     _pagingController.addPageRequestListener((pageKey) {
       findUserFlashcards(pageKey, _pagingController, setId: widget.setId);
     });
-
-    super.initState();
   }
 
   @override

--- a/mobile/lib/app/Profile/widgets/settings_list.dart
+++ b/mobile/lib/app/Profile/widgets/settings_list.dart
@@ -12,7 +12,7 @@ class SettingsList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final signOut = ref.read(authRepositoryProvider).signOut;
 
-    // It's more prefferable to use InkWell and Ink instead of ListView and ListTile
+    // TODO: It's more prefferable to use InkWell and Ink instead of ListView and ListTile
     return BottomSheetWrapper(
       padding: const EdgeInsets.all(8),
       children: [


### PR DESCRIPTION
## Overview

Animate navigation to sets in the profile tab

## Test cases

1. Open the app on the Home tab with at least two sets added
2. Tap My Sets

## Issue

closes [IMB-472](https://www.notion.so/Bug-FE-Wrong-redirect-after-click-on-My-sets-button-on-home-page-17a75429ec6580e7b410e548045ac675?pvs=4)
