### PR TITLE
IMB-473: Fix showing terms and conditions on Android

### DIFF
--- a/mobile/lib/app/Welcome/presentation/welcome_screen.dart
+++ b/mobile/lib/app/Welcome/presentation/welcome_screen.dart
@@ -28,11 +28,16 @@ class WelcomeScreen extends ConsumerWidget {
   }
 
   void openTerms(BuildContext context) {
+    String termsAndConditionsUrl =
+        'https://cdn.prod.website-files.com/663dec74d369b9ac82ea80bc/66ddd7c1c5e6c9bbd189dae9_Terms%20of%20use.pdf';
+    if (Platform.isAndroid) {
+      termsAndConditionsUrl =
+          'https://docs.google.com/gview?embedded=true&url=$termsAndConditionsUrl';
+    }
     AutoRouter.of(context).push(
       WebViewRoute(
         title: 'Terms and conditions',
-        url:
-            'https://cdn.prod.website-files.com/663dec74d369b9ac82ea80bc/66ddd7c1c5e6c9bbd189dae9_Terms%20of%20use.pdf',
+        url: termsAndConditionsUrl,
       ),
     );
   }


### PR DESCRIPTION
## Overview

-  Fix showing terms and conditions on Android

## Test cases

- Open the app as a new user
- Tap 'Terms and conditions'

## Issue

closes [IMB-473](https://www.notion.so/Bug-FE-White-screen-after-click-on-Terms-and-Conditions-17a75429ec6580b3b4a5c1797e09573c?pvs=4)
