### PR TITLE
IMB-402: Prevent Starting Quiz with Insufficient Flashcards

### DIFF
--- a/mobile/lib/app/Set/presentation/set_screen.dart
+++ b/mobile/lib/app/Set/presentation/set_screen.dart
@@ -9,6 +9,7 @@ import 'package:mobile/app/Set/widgets/SetAppBar/set_app_bar.dart';
 import 'package:mobile/app/Set/widgets/SetAppBar/set_app_bar_controller.dart';
 import 'package:mobile/app/Set/widgets/flashcards_group_widget.dart';
 import 'package:mobile/atoms/analytic_click_events.dart';
+import 'package:mobile/atoms/type_setting.dart';
 import 'package:mobile/components/button.dart';
 import 'package:mobile/utils/analytics_engine.dart';
 
@@ -21,12 +22,16 @@ class SetScreen extends ConsumerWidget {
     final set = ref.watch(setServiceProvider);
 
     final setFlashcards = ref.watch(findSetFlashcardsProvider);
+    final isEnoughFlashcards =
+        (set?.flashcards?.length ?? 0) >= kMinimalAmountOfFlashcardsToStartQuiz;
 
     return Layout(
       SingleChildScrollView(
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Button(
+              disabled: !isEnoughFlashcards,
               onPressed: () {
                 analyticsEngine.trackClick(AnalyticClickEvents.setStartQuiz);
                 SetAppBarController.startQuiz(
@@ -37,6 +42,14 @@ class SetScreen extends ConsumerWidget {
               label: 'Start quiz',
               expanded: true,
             ),
+            if (!isEnoughFlashcards) ...[
+              const SizedBox(height: 8),
+              const TypeSetting(
+                'You have to add at least 2 flashcards to start a quiz',
+                variant: TextVariants.bodySmall,
+                style: TextStyle(color: Colors.grey),
+              ),
+            ],
             const SizedBox(height: 16),
             setFlashcards.when(
               data: (data) => Column(


### PR DESCRIPTION
## Overview

Prevent Starting Quiz with Insufficient Flashcards

## Test cases

- Try to start the quiz for an empty set
- Try to start the quiz for a set with at least 2 flashcards

## Issue

closes [IMB-402](https://www.notion.so/Prevent-Starting-Quiz-with-Insufficient-Flashcards-15075429ec65800dae26e76fbc096629?pvs=4)
